### PR TITLE
fix: simplify yarn add suggestion

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -1,8 +1,7 @@
 ## Installation
 
 ```sh
-yarn add angular-skyhook
-yarn add react-dnd-html5-backend
+yarn add angular-skyhook react-dnd-html5-backend
 ```
 
 You might consider `angular-skyhook-multi-backend` instead of the HTML5


### PR DESCRIPTION
I'm just getting started trying your library out, but, as suggested in the getting started guide, I copy and pasted the provided `yarn add` commands into terminal to begin and then immediately went *D'OH!*

My computer's probably slower than yours (it's about to turn 10), I *think* adding the dependencies as separate `add` commands is noticeably slower than combining them into one. Though I haven't actually benchmarked it.